### PR TITLE
Extend witness list in voting Interface

### DIFF
--- a/app/components/Account/AccountVoting.jsx
+++ b/app/components/Account/AccountVoting.jsx
@@ -236,7 +236,7 @@ class AccountVoting extends React.Component {
                 });
             const lastActive = active.last() || `1.${isWitness ? "6" : "5"}.1`;
             lastIdx = parseInt(lastActive.split(".")[2], 10);
-            for (var i = 0; i <= lastIdx + 10; i++) {
+            for (var i = 0; i <= lastIdx + 50; i++) {
                 vote_ids.push(`1.${isWitness ? "6" : "5"}.${i}`);
             }
         } else {


### PR DESCRIPTION
This pull request addresses an issue identified in the R2 client related to the witnesses list available for voting. We noticed a difference in the number of witnesses available for voting compared to the list returned from the CLI wallet. The list available for voting was truncated, limiting the range of choices for users.

The problem was rooted in the _getVoteObjects method, specifically in the way the vote_ids array was populated. Initially, this array was limited to include only 10 additional indices beyond the last active witness or committee member. This limitation resulted in a shorter list of available witnesses for voting compared to the full list accessible through the CLI wallet.

<h2>User interface</h2>

- [ ] Dark
- [ ] Light
- [x] Midnight

![Screenshot 2024-01-03 at 14 47 25](https://github.com/R-Squared-Project/R-Squared-portal/assets/103828231/6f0c875a-58b1-41b2-9101-112abaee4b40)
